### PR TITLE
Scottx611x/update track metadata

### DIFF
--- a/context/on_startup.py
+++ b/context/on_startup.py
@@ -24,9 +24,8 @@ def write_igv_configuration():
         tracks.append(
             {
                 "name": "{} - {}".format(
-                    node_data["node_solr_info"][
-                        "filename_Characteristics_generic_s"],
-                    node_data["node_solr_info"]["name"]
+                    node_data["node_solr_info"]["name"],
+                    node_data["file_url"]
                 ),
                 "url":  node_data["file_url"]
             }

--- a/input_fixtures/good/input.json
+++ b/input_fixtures/good/input.json
@@ -32,7 +32,6 @@
         "technology_Characteristics_generic_s": "DNA microarray",
         "measurement_Characteristics_generic_s": "transcription profiling",
         "organism_Characteristics_720_361_s": "Mus musculus",
-        "filename_Characteristics_generic_s": "040909%20DT%20MOUSE%20430%202.0%20Sample%20526.CEL",
         "organism_part_Characteristics_generic_s": "Bone marrow",
         "technology_source_Characteristics_generic_s": "OBI",
         "REFINERY_FILETYPE_720_361_s": "Affymetrix Probe Results File",

--- a/input_fixtures/missing_assembly/input.json
+++ b/input_fixtures/missing_assembly/input.json
@@ -32,7 +32,6 @@
         "technology_Characteristics_generic_s": "DNA microarray",
         "measurement_Characteristics_generic_s": "transcription profiling",
         "organism_Characteristics_720_361_s": "Mus musculus",
-        "filename_Characteristics_generic_s": "040909%20DT%20MOUSE%20430%202.0%20Sample%20526.CEL",
         "organism_part_Characteristics_generic_s": "Bone marrow",
         "technology_source_Characteristics_generic_s": "OBI",
         "REFINERY_FILETYPE_720_361_s": "Affymetrix Probe Results File",

--- a/input_fixtures/no_parameters/input.json
+++ b/input_fixtures/no_parameters/input.json
@@ -32,7 +32,6 @@
         "technology_Characteristics_generic_s": "DNA microarray",
         "measurement_Characteristics_generic_s": "transcription profiling",
         "organism_Characteristics_720_361_s": "Mus musculus",
-        "filename_Characteristics_generic_s": "040909%20DT%20MOUSE%20430%202.0%20Sample%20526.CEL",
         "organism_part_Characteristics_generic_s": "Bone marrow",
         "technology_source_Characteristics_generic_s": "OBI",
         "REFINERY_FILETYPE_720_361_s": "Affymetrix Probe Results File",


### PR DESCRIPTION
The metadata key (`filename_Characteristics_generic_s` ) we were using to give a little extra info per track coming from Refinery's Solr index doesn't exist after https://github.com/refinery-platform/refinery-platform/pull/2630 which leads to `KeyError('filename_Characteristics_generic_s',)` being displayed in the browser on VisualizationTool launch.

Just updating to use something reasonable that exists at the moment.