### PR TITLE
Fix all images being pushed bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ python:
 install:
   - pip install -r requirements.txt
 script:
-- source define_repo.sh
-- ./build_run_test.sh
+- python test.py
 after_success:
 - IMAGE=`docker ps --latest --format '{{ .Image }}'` # TODO: with more containers, can't rely on ordering
 - echo $IMAGE

--- a/build_run_test.sh
+++ b/build_run_test.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-source define_repo.sh
-
-python test.py

--- a/define_repo.sh
+++ b/define_repo.sh
@@ -2,4 +2,4 @@
 
 OWNER=gehlenborglab
 export NAME=docker_igv_js
-export REPO=$OWNER/$NAME:latest
+export REPO=$OWNER/$NAME

--- a/define_repo.sh
+++ b/define_repo.sh
@@ -2,4 +2,4 @@
 
 OWNER=gehlenborglab
 export NAME=docker_igv_js
-export REPO=$OWNER/$NAME
+export REPO=$OWNER/$NAME:latest

--- a/define_repo.sh
+++ b/define_repo.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-OWNER=gehlenborglab
-export NAME=docker_igv_js
-export REPO=$OWNER/$NAME

--- a/test_utils.py
+++ b/test_utils.py
@@ -33,8 +33,8 @@ class TestContainerRunner(object):
 
     def __init__(self):
         self.client = docker.from_env()
-        self.image_name = os.environ["NAME"]
-        self.repository = os.environ["REPO"]
+        self.image_name = "docker_igv_js"
+        self.repository = "gehlenborglab/docker_igv_js"
         self.containers = []
         self.test_fixture_server = TestFixtureServer()
         self.test_fixture_server.start_server_in_background()

--- a/test_utils.py
+++ b/test_utils.py
@@ -50,7 +50,7 @@ class TestContainerRunner(object):
             self.cleanup_containers()
 
     def _pull_image(self):
-        self.client.images.pull(self.repository)
+        self.client.images.pull(self.repository + ":latest")
 
     def _build_image(self):
         print("Building image: {}".format(self.image_name))


### PR DESCRIPTION
I believe the docker-py library defaults to pulling all images from a repo unless it sees a specific tag.

The same issue occurred  in [refinery-higlass-docker](https://github.com/refinery-platform/refinery-higlass-docker/commit/c9c0f774c7204afaea86f02bf7a292d2cf19fb4c)

This PR should also include the removal of the two shell scripts, and just move things into Python, but I'd like to see this work in Travis first

- [x] [Confirm that not every image is being pushed to dockerhub anymore](https://hub.docker.com/r/gehlenborglab/docker_igv_js/tags/)
- [x] Remove shell scripts