### PR TITLE
Pull only latest

### DIFF
--- a/test_utils.py
+++ b/test_utils.py
@@ -50,7 +50,9 @@ class TestContainerRunner(object):
             self.cleanup_containers()
 
     def _pull_image(self):
-        self.client.images.pull(self.repository)
+        latest_image = self.repository + ":latest"
+        print("Pulling image: {}".format(latest_image))
+        self.client.images.pull(latest_image)
 
     def _build_image(self):
         print("Building image: {}".format(self.image_name))


### PR DESCRIPTION
All images on docker hub are being updated with every push. No real harm done, except it looks weird, and we lose any record of when different versions were first pushed. Scott suggests this fix.