### PR TITLE
Add index file for bam visualizations

### DIFF
--- a/context/on_startup.py
+++ b/context/on_startup.py
@@ -30,16 +30,17 @@ def write_igv_configuration():
         assembly
     )
     for node_data in config_data["node_info"].values():
+        file_url = node_data["file_url"]
         track = {
             "name": "{} - {}".format(
                 node_data["node_solr_info"]["name"],
-                node_data["file_url"]
+                file_url
             ),
-            "url": node_data["file_url"]
+            "url": file_url
         }
-        if '.bam' == os.path.splitext(track['name']):
-            # assume that there is only one auxiliary file for bam igv and it's
-            # the .bai file
+        if '.bam' == os.path.splitext(file_url):
+            # Assume that there is only one auxiliary file for bam igv and it's
+            # the .bai file.
             track['type'] = 'alignment'
             track['format'] = 'bam'
             track['indexURL'] = node_data['auxiliary_file_list'][0]

--- a/context/on_startup.py
+++ b/context/on_startup.py
@@ -40,6 +40,8 @@ def write_igv_configuration():
         if '.bam' in track['name']:
             # assume that there is only one auxiliary file for bam igv and it's
             # the .bai file
+            track['type'] = 'alignment'
+            track['format'] = 'bam'
             track['indexURL'] = node_data['auxiliary_file_list'][0]
         tracks.append(track)
     reference = {

--- a/context/on_startup.py
+++ b/context/on_startup.py
@@ -30,15 +30,18 @@ def write_igv_configuration():
         assembly
     )
     for node_data in config_data["node_info"].values():
-        tracks.append(
-            {
-                "name": "{} - {}".format(
-                    node_data["node_solr_info"]["name"],
-                    node_data["file_url"]
-                ),
-                "url": node_data["file_url"]
-            }
-        )
+        track = {
+            "name": "{} - {}".format(
+                node_data["node_solr_info"]["name"],
+                node_data["file_url"]
+            ),
+            "url": node_data["file_url"]
+        }
+        if '.bam' in track['name']:
+            # assume that there is only one auxiliary file for bam igv and it's
+            # the .bai file
+            track['indexURL'] = node_data['auxiliary_file_list'][0]
+        tracks.append(track)
     reference = {
         "fastaURL": url_base + assembly + ".fa",
         "indexURL": url_base + assembly + ".fa.fai",

--- a/context/on_startup.py
+++ b/context/on_startup.py
@@ -37,7 +37,7 @@ def write_igv_configuration():
             ),
             "url": node_data["file_url"]
         }
-        if '.bam' in track['name']:
+        if '.bam' == os.path.splitext(track['name']):
             # assume that there is only one auxiliary file for bam igv and it's
             # the .bai file
             track['type'] = 'alignment'


### PR DESCRIPTION
By fixing https://github.com/refinery-platform/refinery-platform/issues/2718 and updating the API, all we need to do here is add the indexURL for bam files.  We should probably hold off on merging this until after the next release (i.e after Monday/Tuesday). No reason we can't review it though!